### PR TITLE
Avoid triggering onSelect callback during create

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -110,7 +110,7 @@ export default {
         this.change(defaultValue);
       }
 
-      this.pikaday.setDate(defaultValue);
+      this.pikaday.setDate(defaultValue, true);
 
       if (this.mergedOptions.bound === false) {
         this.hide();


### PR DESCRIPTION
According to pikaday's documentation, onSelect should only be called when the user explicitly sets a date.